### PR TITLE
Make it work when rendered in server

### DIFF
--- a/src/Resize-Handler.js
+++ b/src/Resize-Handler.js
@@ -4,11 +4,15 @@ class ResizeHandler {
   constructor() {
     this._queue = []
     this.update = debounce(this.update.bind(this), 150)
-    window.addEventListener('resize', this.update)
+    if (typeof window !== 'undefined') {
+      window.addEventListener('resize', this.update)
+    }
   }
 
   destroy() {
-    window.removeEventListener('resize', this.update)
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('resize', this.update)
+    }
   }
 
   add(component) {


### PR DESCRIPTION
Looks like `window` is not defined when pre-rendering the component on the server. This change allows the awesome `react-motion-ui-pack` to be used in isomorphic apps.

I hope this is useful!
