### PR TITLE
Don't depend directly on React/ReactDOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,9 @@
     "style-loader": "^0.12.3",
     "webpack": "^1.9.12",
     "webpack-dev-server": "^1.9.0"
+  },
+  "peerDependencies": {
+    "react": ">0.13.0",
+    "react-dom": ">0.13.0"  
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
   },
   "homepage": "https://github.com/souporserious/react-measure",
   "dependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0",
     "react-addons-shallow-compare": "^0.14.0",
     "lodash.debounce": "^3.1.1"
   },


### PR DESCRIPTION
Having these as dependents makes it impossible to upgrade to React 0.15 and beyond until this library does.

Also it's just not necessary. A React library can safely assume that React is around :) If you do rely on specific React apis that were introduced only recently, you can add `peerDependencies` for them.
