### PR TITLE
When unmounting, call uninstall in addition to removeAllListeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react-dom": ">0.13.0"
   },
   "dependencies": {
-    "element-resize-detector": "^1.1.5",
+    "element-resize-detector": "^1.1.9",
     "get-node-dimensions": "^0.1.1"
   },
   "devDependencies": {

--- a/src/Measure.jsx
+++ b/src/Measure.jsx
@@ -49,6 +49,8 @@ class Measure extends Component {
 
   componentWillUnmount() {
     resizeDetector().removeAllListeners(this._node)
+    resizeDetector().uninstall(this._node)
+    this._node = null
   }
 
   getDimensions(node = this._node, clone) {


### PR DESCRIPTION
If uninstall isn't called, and I use elements like material-ui's FlatButtons in the Measure element (instead of just <div>s), I get errors like this one:

Uncaught TypeError: Cannot read property 'appendChild' of null
getCloneDimensions @ get-clone-dimensions.js:39
getNodeDimensions @ get-node-dimensions.js:22
getDimensions @ Measure.js:118
Measure.measure @ Measure.js:56
(anonymous function) @ Measure.js:92
addListener @ element-resize-detector.js:161
onElementDetectable @ element-resize-detector.js:236
ready @ scroll.js:561
process @ batch-processor.js:124
processBatch @ batch-processor.js:37

which indicates that an event on a node was fired, whose parent node is gone. This happens after a Measure element is removed (e.g. because a list item was removed).
