### PR TITLE
Prevent leaking resize observers.

### DIFF
--- a/src/Measure.jsx
+++ b/src/Measure.jsx
@@ -42,14 +42,11 @@ class Measure extends Component {
   }
 
   componentDidMount() {
+    this.resizeObserver = new ResizeObserver(() => this.measure())
     this._setDOMNode()
 
     // measure on first render
     this.measure()
-
-    // add component to resize observer to detect changes on resize
-    this.resizeObserver = new ResizeObserver(() => this.measure())
-    this.resizeObserver.observe(this._node)
   }
 
   componentWillReceiveProps({config, whitelist, blacklist}) {
@@ -67,7 +64,10 @@ class Measure extends Component {
   }
 
   _setDOMNode() {
+    if (this._node) this.resizeObserver.disconnect(this._node)
     this._node = ReactDOM.findDOMNode(this)
+        // add component to resize observer to detect changes on resize
+    this.resizeObserver.observe(this._node)
   }
 
   getDimensions(


### PR DESCRIPTION
I'm getting a lot of `ResizeObserver loop limit exceeded` messages from my app.
I'm not sure whether this PR solves this issue, but it seems like a likely candidate:
Whenever a new `this._node` is set, this PR makes sure its associated observer is disconnected and a new one is set up.