### PR TITLE
Proposal: withMeasure HOC

### DIFF
--- a/src/react-measure.js
+++ b/src/react-measure.js
@@ -1,1 +1,2 @@
 export default from './Measure';
+export withMeasure from './withMeasure';

--- a/src/withMeasure.js
+++ b/src/withMeasure.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import Measure from 'react-measure'
+
+const withMeasure = (
+  dimensionsToInject = ['width', 'height', 'top', 'right', 'bottom', 'left'],
+  props = {}
+) => WrappedComponent => wrappedComponentProps => (
+  <Measure {...props}>
+    {dimensions => {
+      const injectedDimensions = {}
+      dimensionsToInject.forEach(key => {
+        injectedDimensions[key] = dimensions[key]
+      })
+      return (
+        <WrappedComponent {...injectedDimensions} {...wrappedComponentProps} />
+      )
+    }}
+  </Measure>
+)
+
+export default withMeasure


### PR DESCRIPTION
Hi, thank you for this super useful lib. I've been using it in my project to inject dimensions props into components so that the components can render their content accordingly (e.g. for charts). Lately I've created myself a higher order component to perform the injection of dimensions as props. I thought it could be valuable for the lib.

Usage:
```javascript
import {withMeasure} from 'react-measure'

// inject all dimensions by default, <Measure /> is used with the default props
// MeasuredComponent now has height, width, and **ALL** other dimensions in its props
const MeasuredComponent = withMeasure()(MyComponent)

// inject only some dimensions
// MeasuredComponent now has height, width, and **NO** other dimensions in its props
const MeasuredComponent = withMeasure(['height', 'width'])(MyComponent)

// provide custom props to <Measure /> (all current props are supported)
// MeasuredComponent now has height, width in its props, but the props only update when height changes
const MeasuredComponent = withMeasure(['height', 'width'], {
  whitelist: ['height']
})(MyComponent)
```