### PR TITLE
Fix missing underscore

### DIFF
--- a/src/with-content-rect.js
+++ b/src/with-content-rect.js
@@ -54,7 +54,7 @@ function withContentRect(types) {
       }
 
       componentWillUnmount() {
-        if (this.resizeObserver && this._node) {
+        if (this._resizeObserver && this._node) {
           this._resizeObserver.disconnect(this._node)
         }
       }


### PR DESCRIPTION
This prevents proper cleanup and leads to exceptions

(Proposal: it might be nicer to deal with connecting/disconnecting within the `handleRef` method, as the ref might change without mounting/unmounting. Not too sure about whether this is the actual behaviour of refs though.)