### PR TITLE
Disconnect correct node within `handleRef`

### DIFF
--- a/src/with-content-rect.js
+++ b/src/with-content-rect.js
@@ -51,15 +51,14 @@ function withContentRect(types) {
       }
 
       _handleRef = node => {
-        this._node = node
-
         if (this._resizeObserver) {
           if (node) {
             this._resizeObserver.observe(node)
           } else {
-            this._resizeObserver.disconnect(node)
+            this._resizeObserver.disconnect(this._node)
           }
         }
+        this._node = node
 
         if (typeof this.props.innerRef === 'function') {
           this.props.innerRef(node)


### PR DESCRIPTION
previously it would do `this._resizeObserver.disconnect(null)` :)