### PR TITLE
Allow children to be any element

### DIFF
--- a/src/with-content-rect.js
+++ b/src/with-content-rect.js
@@ -15,7 +15,7 @@ function withContentRect(types) {
         margin: PropTypes.bool,
         innerRef: PropTypes.func,
         onResize: PropTypes.func,
-        children: PropTypes.func,
+        children: PropTypes.element,
       }
 
       state = {


### PR DESCRIPTION
Currently it's required to be a function -- but there's really no reason it can't be any react element. 

Fixes #75 