### PR TITLE
Add ES6 module build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,32 @@
 {
-  "presets": [
-    "es2015",
-    "stage-0",
-    "react"
-  ],
-  "plugins": [
-    "add-module-exports"
-  ]
+
+  "env": {
+    "development": {
+      "presets": [
+        "es2015",
+        "stage-0",
+        "react"
+      ],
+      "plugins": [
+        "add-module-exports"
+      ]
+    },
+    "production": {
+      "presets": [
+        "es2015",
+        "stage-0",
+        "react"
+      ],
+      "plugins": [
+        "add-module-exports"
+      ]
+    },
+    "es": {
+      "presets": [
+        ["es2015", { "modules": false }],
+        "stage-0",
+        "react"
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "version": "2.0.2",
   "description": "Compute measurements of React components.",
   "main": "lib/react-measure.js",
+  "module": "lib/es/react-measure.js",
   "files": [
     "dist",
     "lib"
   ],
   "scripts": {
     "build:lib": "babel src --out-dir lib",
-    "build": "npm run build:lib && NODE_ENV=production webpack --config webpack.prod.config.js",
+    "build:es": "BABEL_ENV=es babel src --out-dir lib/es",
+    "build": "npm run build:lib && npm run build:es && NODE_ENV=production webpack --config webpack.prod.config.js",
     "dev": "webpack-dev-server --inline --hot --progress --colors --host 0.0.0.0 --devtool eval",
     "postbuild": "NODE_ENV=production TARGET=minify webpack --config webpack.prod.config.js",
     "prebuild": "rm -rf dist && mkdir dist",


### PR DESCRIPTION
This PR adds build with ES6 modules preserved. It enables webpack & friends to do tree shaking and scope hoisting.

It saved some kB of space for me also.