### PR TITLE
Update resize-observer-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "get-node-dimensions": "^1.2.0",
     "prop-types": "^15.5.10",
-    "resize-observer-polyfill": "^1.4.2"
+    "resize-observer-polyfill": "^1.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",


### PR DESCRIPTION
Updating the polyfill to the most recent version fixes issues with rendering the `Measure` component in the context of an iframe, for example with the https://github.com/ryanseddon/react-frame-component `Frame` component.