### PR TITLE
Move children propType from with-content-rect to Measure

### DIFF
--- a/src/Measure.jsx
+++ b/src/Measure.jsx
@@ -1,8 +1,12 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import withContentRect from './with-content-rect'
 
-function Measure({ measure, measureRef, contentRect, children }) {
+const Measure =  withContentRect()(function Measure ({ measure, measureRef, contentRect, children }) {
   return children({ measure, measureRef, contentRect })
-}
+})
 
-export default withContentRect()(Measure)
+Measure.displayName = 'Measure'
+Measure.propTypes.children = PropTypes.func
+
+export default Measure

--- a/src/with-content-rect.js
+++ b/src/with-content-rect.js
@@ -6,7 +6,7 @@ import getContentRect from './get-content-rect'
 
 function withContentRect(types) {
   return WrappedComponent =>
-    class extends Component {
+    class WithContentRect extends Component {
       static propTypes = {
         client: PropTypes.bool,
         offset: PropTypes.bool,
@@ -15,7 +15,6 @@ function withContentRect(types) {
         margin: PropTypes.bool,
         innerRef: PropTypes.func,
         onResize: PropTypes.func,
-        children: PropTypes.element,
       }
 
       state = {


### PR DESCRIPTION
Fixes #116

`withContentRect` actually doesn't use `children` property so it should be agnostic of its type

This also adds some dispayNames