### PR TITLE
Fix initial onResize delay caused by requestAnimationFrame

### DIFF
--- a/src/__tests__/Measure.test.js
+++ b/src/__tests__/Measure.test.js
@@ -89,6 +89,11 @@ describe('Measure', () => {
 
       expect(ref.current.id).toBe('child2')
     })
+    it('should trigger onResize when componentDidMount is called', () => {
+      const onResize = jest.fn()
+      render(<MeasureWith onResize={onResize} />, container)
+      expect(onResize).toHaveBeenCalledTimes(1)
+    })
     it('should trigger onResize when resizeObserver callback is called', () => {
       const onResize = jest.fn()
 
@@ -96,7 +101,7 @@ describe('Measure', () => {
       resizeObserver.callback()
       jest.runAllTimers()
 
-      expect(onResize).toHaveBeenCalledTimes(1)
+      expect(onResize).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/src/with-content-rect.js
+++ b/src/with-content-rect.js
@@ -39,6 +39,15 @@ function withContentRect(types) {
         this._resizeObserver = new ResizeObserver(this.measure)
         if (this._node !== null) {
           this._resizeObserver.observe(this._node)
+
+          if (typeof this.props.onResize === 'function') {
+            this.props.onResize(
+              getContentRect(
+                this._node,
+                types || getTypes(this.props)
+              )
+            )
+          }
         }
       }
 


### PR DESCRIPTION
Immediately calls the onResize callback on `componentDidMount`.

The callback is now being called within a requestAnimationFrame to prevent a `loop limit exceeded error` #133.
However, this causes an initial delay and is noticeable in some applications.