### PR TITLE
Set innerRef before start resize observing

### DIFF
--- a/src/__tests__/Measure.test.js
+++ b/src/__tests__/Measure.test.js
@@ -89,6 +89,22 @@ describe('Measure', () => {
 
       expect(ref.current.id).toBe('child2')
     })
+    it('should trigger onResize after setting innerRef', () => {
+      const ref = createRef()
+
+      let refOnResize = undefined;
+      const onResize = () => refOnResize = ref.current
+      render(
+        <MeasureWith
+          onResize={onResize}
+          innerRef={ref}
+          children={({ measureRef }) => <div id={'child'} ref={measureRef} />}
+        />,
+        container
+      )
+      expect(refOnResize).not.toBe(null)
+      expect(refOnResize.id).toBe('child')
+    })
     it('should trigger onResize when componentDidMount is called', () => {
       const onResize = jest.fn()
       render(<MeasureWith onResize={onResize} />, container)

--- a/src/with-content-rect.js
+++ b/src/with-content-rect.js
@@ -83,10 +83,6 @@ function withContentRect(types) {
 
         this._node = node
 
-        if (this._resizeObserver !== null && this._node !== null) {
-          this._resizeObserver.observe(this._node)
-        }
-
         const { innerRef } = this.props
         if (innerRef) {
           if (typeof innerRef === 'function') {
@@ -94,6 +90,10 @@ function withContentRect(types) {
           } else {
             innerRef.current = this._node
           }
+        }
+
+        if (this._resizeObserver !== null && this._node !== null) {
+          this._resizeObserver.observe(this._node)
         }
       }
 


### PR DESCRIPTION
The `onResize` handler may sometimes want to use the element being referenced. It would be better that the reference is updated before the handler is invoked.