### PR TITLE
Use the local window object of the observed node

### DIFF
--- a/src/get-window-of.js
+++ b/src/get-window-of.js
@@ -1,0 +1,15 @@
+/**
+ * Returns the global window object associated with provided element.
+ */
+function getWindowOf(target) {
+  // Assume that the element is an instance of Node, which means that it
+  // has the "ownerDocument" property from which we can retrieve a
+  // corresponding global object.
+  const ownerGlobal = target && target.ownerDocument && target.ownerDocument.defaultView
+
+  // Return the local window object if it's not possible extract one from
+  // provided element.
+  return ownerGlobal || window
+};
+
+export default getWindowOf

--- a/src/with-content-rect.js
+++ b/src/with-content-rect.js
@@ -4,6 +4,7 @@ import ResizeObserver from 'resize-observer-polyfill'
 
 import getTypes from './get-types'
 import getContentRect from './get-content-rect'
+import getWindowOf from './get-window-of'
 
 function withContentRect(types) {
   return WrappedComponent =>
@@ -35,6 +36,8 @@ function withContentRect(types) {
 
       _node = null
 
+      _window = null
+
       componentDidMount() {
         this._resizeObserver = new ResizeObserver(this.measure)
         if (this._node !== null) {
@@ -49,11 +52,14 @@ function withContentRect(types) {
       }
 
       componentWillUnmount() {
+        if (this._window !== null) {
+          this._window.cancelAnimationFrame(this._animationFrameID)
+        }
+
         if (this._resizeObserver !== null) {
           this._resizeObserver.disconnect()
           this._resizeObserver = null
         }
-        window.cancelAnimationFrame(this._animationFrameID)
       }
 
       measure = entries => {
@@ -66,7 +72,7 @@ function withContentRect(types) {
           contentRect.entry = entries[0].contentRect
         }
 
-        this._animationFrameID = window.requestAnimationFrame(() => {
+        this._animationFrameID = this._window.requestAnimationFrame(() => {
           if (this._resizeObserver !== null) {
             this.setState({ contentRect })
             if (typeof this.props.onResize === 'function') {
@@ -82,6 +88,7 @@ function withContentRect(types) {
         }
 
         this._node = node
+        this._window = getWindowOf(this._node)
 
         if (this._resizeObserver !== null && this._node !== null) {
           this._resizeObserver.observe(this._node)


### PR DESCRIPTION
When observing resizeable elements rendered in a remote document via a portal, requestAnimationFrame calls can hang if they are not invoked in the local window of the node being observed. Most browsers will defer requestAnimationFrame callbacks that are called in background tabs or iframes until the tab or frame becomes visible again.

This PR ensures that `requestAnimationFrame` calls are made in the local window of the node being observed to avoid the browser pausing these `requestAnimationFrame` calls.