### PR TITLE
Use ResizeObserver of local window object

### DIFF
--- a/src/with-content-rect.js
+++ b/src/with-content-rect.js
@@ -39,7 +39,9 @@ function withContentRect(types) {
       _window = null
 
       componentDidMount() {
-        this._resizeObserver = new ResizeObserver(this.measure)
+        this._resizeObserver = this.window !== null
+          ? new this._window.ResizeObserver(this.measure)
+          : new ResizeObserver(this.measure);
         if (this._node !== null) {
           this._resizeObserver.observe(this._node)
 


### PR DESCRIPTION
Similar to PR #146 , when resizing elements in a remote document via a portal, ResizeObserver stop working when the original window is inactive. This PR ensures that the `ResizeObserver` are created using the local `window` of the node being observed.