### PR TITLE
Default to global (possibly polyfilled) ResizeObserver if the local window does not have ResizeObserver

### DIFF
--- a/src/with-content-rect.js
+++ b/src/with-content-rect.js
@@ -39,7 +39,7 @@ function withContentRect(types) {
       _window = null
 
       componentDidMount() {
-        this._resizeObserver = this.window !== null
+        this._resizeObserver = (this._window !== null && this._window.ResizeObserver)
           ? new this._window.ResizeObserver(this.measure)
           : new ResizeObserver(this.measure);
         if (this._node !== null) {


### PR DESCRIPTION
This PR is a follow-up of the previous PR (#147 ) which introduce the usage of `ResizeObserver` of the local `window` object. After PR #147 , I find that many tests in my org's code base is breaking with the below error:
```
TypeError: this._window.ResizeObserver is not a constructor
```

Hence this PR is a follow up, to resort to the global (possibly polyfilled) `ResizeObserver` if `this._window.ResizeObserver` does not exist. (Apologies for introducing this issue 🙏 🙏 🙏  )

Also, there's a typo in the previous PR 🙈   should be `this._window` instead of `this.window`